### PR TITLE
Add link underline color

### DIFF
--- a/Maaku.podspec
+++ b/Maaku.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Maaku"
-  s.version      = "0.3.1"
+  s.version      = "0.4.0"
   s.summary      = "Swift cmark-gfm wrapper with a Swift friendly representation of the AST"
 
   s.description  = <<-DESC

--- a/Sources/Maaku/Core/Inline/Link.swift
+++ b/Sources/Maaku/Core/Inline/Link.swift
@@ -116,7 +116,9 @@ public extension Link {
         if let url = self.url {
             let attributes: [NSAttributedStringKey: Any] = [
                 .font: style.fonts.current,
-                .foregroundColor: style.colors.link, .link: url
+                .foregroundColor: style.colors.link,
+                .link: url,
+                .underlineColor: style.colors.linkUnderline
             ]
             attributed.addAttributes(attributes, range: NSRange(location: 0, length: attributed.string.utf16.count))
         }

--- a/Sources/Maaku/Core/Style.swift
+++ b/Sources/Maaku/Core/Style.swift
@@ -89,6 +89,9 @@ public protocol ColorStyle {
     /// Link foreground color
     var link: Color { get set }
 
+    /// Link underline color
+    var linkUnderline: Color { get set }
+
     /// Paragraph foreground color
     var paragraph: Color { get set }
 }
@@ -190,6 +193,9 @@ public struct DefaultColorStyle: ColorStyle {
     /// The link color.
     public var link: Color
 
+    /// The link underline color.
+    public var linkUnderline: Color
+
     /// The paragraph color.
     public var paragraph: Color
 
@@ -202,6 +208,7 @@ public struct DefaultColorStyle: ColorStyle {
         h6 = .black
         paragraph = .black
         link = .blue
+        linkUnderline = .blue
         current = .black
         inlineCodeBackground = Color(white: 0.95, alpha: 1.0)
         inlineCodeForeground = Color(red: 0.91, green: 0.11, blue: 0.25, alpha: 1.00)


### PR DESCRIPTION
Link underline color can be set to UIColor.clear to remove the underline, or set to a different color as needed.