### PR TITLE
Tests for API usage shouldn't have @testable

### DIFF
--- a/Tests/MaakuTests/CMark/CMDocumentSpec.swift
+++ b/Tests/MaakuTests/CMark/CMDocumentSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Container/BlockQuoteSpec.swift
+++ b/Tests/MaakuTests/Core/Container/BlockQuoteSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Container/FootnoteDefinitionSpec.swift
+++ b/Tests/MaakuTests/Core/Container/FootnoteDefinitionSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Container/ListItemSpec.swift
+++ b/Tests/MaakuTests/Core/Container/ListItemSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Container/OrderedListSpec.swift
+++ b/Tests/MaakuTests/Core/Container/OrderedListSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Container/UnorderedListSpec.swift
+++ b/Tests/MaakuTests/Core/Container/UnorderedListSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/DocumentSpec.swift
+++ b/Tests/MaakuTests/Core/DocumentSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Extensions/AutolinkSpec.swift
+++ b/Tests/MaakuTests/Core/Extensions/AutolinkSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Extensions/StrikethroughSpec.swift
+++ b/Tests/MaakuTests/Core/Extensions/StrikethroughSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Extensions/TableSpec.swift
+++ b/Tests/MaakuTests/Core/Extensions/TableSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Extensions/TagFilterSpec.swift
+++ b/Tests/MaakuTests/Core/Extensions/TagFilterSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/EmphasisSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/EmphasisSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/FootnoteReferenceSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/FootnoteReferenceSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/ImageSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/ImageSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/InlineCodeSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/InlineCodeSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/InlineHtmlSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/InlineHtmlSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/LineBreakSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/LineBreakSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/LinkSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/LinkSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/SoftBreakSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/SoftBreakSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/StrongSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/StrongSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/TextSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/TextSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Leaf/CodeBlockSpec.swift
+++ b/Tests/MaakuTests/Core/Leaf/CodeBlockSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Leaf/HeadingSpec.swift
+++ b/Tests/MaakuTests/Core/Leaf/HeadingSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Leaf/HorizontalRuleSpec.swift
+++ b/Tests/MaakuTests/Core/Leaf/HorizontalRuleSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Leaf/HtmlBlockSpec.swift
+++ b/Tests/MaakuTests/Core/Leaf/HtmlBlockSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Leaf/ParagraphSpec.swift
+++ b/Tests/MaakuTests/Core/Leaf/ParagraphSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/StyleSpec.swift
+++ b/Tests/MaakuTests/Core/StyleSpec.swift
@@ -16,7 +16,7 @@
     public typealias Color = UIColor
 #endif
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Plugins/YoutubePluginSpec.swift
+++ b/Tests/MaakuTests/Plugins/YoutubePluginSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest


### PR DESCRIPTION
Don't include @testable when testing the API, as it will hide that some items that
should be visible to external users really aren't.

By including the @testable with the Maaku import, you allow the tests to access internal parts of the package. This is fine if you're using internal parts to test that things are actually working, but it isn't a good idea if you're testing the package from the standpoint of what a user will do. So, tests should be separated into "API" tests, and "internal" tests, and only "internal" tests should have "@testable".

As an example, by removing @testable, it shows that Link's initializers aren't public, although other similar classes have public initializers.