### PR TITLE
Make cm node type public

### DIFF
--- a/Sources/Maaku/CMark/CMNodeType.swift
+++ b/Sources/Maaku/CMark/CMNodeType.swift
@@ -16,73 +16,73 @@ public struct CMNodeType: Equatable {
     let rawValue: UInt32
 
     /// The none node type.
-    static let none = CMNodeType(rawValue: CMARK_NODE_NONE.rawValue)
+    public static let none = CMNodeType(rawValue: CMARK_NODE_NONE.rawValue)
 
     /// The document node type.
-    static let document = CMNodeType(rawValue: CMARK_NODE_DOCUMENT.rawValue)
+    public static let document = CMNodeType(rawValue: CMARK_NODE_DOCUMENT.rawValue)
 
     /// The blockquote node type.
-    static let blockQuote = CMNodeType(rawValue: CMARK_NODE_BLOCK_QUOTE.rawValue)
+    public static let blockQuote = CMNodeType(rawValue: CMARK_NODE_BLOCK_QUOTE.rawValue)
 
     /// The list node type.
-    static let list = CMNodeType(rawValue: CMARK_NODE_LIST.rawValue)
+    public static let list = CMNodeType(rawValue: CMARK_NODE_LIST.rawValue)
 
     /// The list item node type.
-    static let item = CMNodeType(rawValue: CMARK_NODE_ITEM.rawValue)
+    public static let item = CMNodeType(rawValue: CMARK_NODE_ITEM.rawValue)
 
     /// The code block node type.
-    static let codeBlock = CMNodeType(rawValue: CMARK_NODE_CODE_BLOCK.rawValue)
+    public static let codeBlock = CMNodeType(rawValue: CMARK_NODE_CODE_BLOCK.rawValue)
 
     /// The HTML block node type.
-    static let htmlBlock = CMNodeType(rawValue: CMARK_NODE_HTML_BLOCK.rawValue)
+    public static let htmlBlock = CMNodeType(rawValue: CMARK_NODE_HTML_BLOCK.rawValue)
 
     /// The custom block node type.
-    static let customBlock = CMNodeType(rawValue: CMARK_NODE_CUSTOM_BLOCK.rawValue)
+    public static let customBlock = CMNodeType(rawValue: CMARK_NODE_CUSTOM_BLOCK.rawValue)
 
     /// The paragraph node type.
-    static let paragraph = CMNodeType(rawValue: CMARK_NODE_PARAGRAPH.rawValue)
+    public static let paragraph = CMNodeType(rawValue: CMARK_NODE_PARAGRAPH.rawValue)
 
     /// The heading node type.
-    static let heading = CMNodeType(rawValue: CMARK_NODE_HEADING.rawValue)
+    public static let heading = CMNodeType(rawValue: CMARK_NODE_HEADING.rawValue)
 
     /// The thematic break (horizontal rule) node type.
-    static let thematicBreak = CMNodeType(rawValue: CMARK_NODE_THEMATIC_BREAK.rawValue)
+    public static let thematicBreak = CMNodeType(rawValue: CMARK_NODE_THEMATIC_BREAK.rawValue)
 
     /// The footnote definition node type.
-    static let footnoteDefinition = CMNodeType(rawValue: CMARK_NODE_FOOTNOTE_DEFINITION.rawValue)
+    public static let footnoteDefinition = CMNodeType(rawValue: CMARK_NODE_FOOTNOTE_DEFINITION.rawValue)
 
     /// The text node type.
-    static let text = CMNodeType(rawValue: CMARK_NODE_TEXT.rawValue)
+    public static let text = CMNodeType(rawValue: CMARK_NODE_TEXT.rawValue)
 
     /// The soft break node type.
-    static let softBreak = CMNodeType(rawValue: CMARK_NODE_SOFTBREAK.rawValue)
+    public static let softBreak = CMNodeType(rawValue: CMARK_NODE_SOFTBREAK.rawValue)
 
     /// The line break node type.
-    static let lineBreak = CMNodeType(rawValue: CMARK_NODE_LINEBREAK.rawValue)
+    public static let lineBreak = CMNodeType(rawValue: CMARK_NODE_LINEBREAK.rawValue)
 
     /// The inline code node type.
-    static let code = CMNodeType(rawValue: CMARK_NODE_CODE.rawValue)
+    public static let code = CMNodeType(rawValue: CMARK_NODE_CODE.rawValue)
 
     /// The inline HTML node type.
-    static let htmlInline = CMNodeType(rawValue: CMARK_NODE_HTML_INLINE.rawValue)
+    public static let htmlInline = CMNodeType(rawValue: CMARK_NODE_HTML_INLINE.rawValue)
 
     /// The inline custom node type.
-    static let customInline = CMNodeType(rawValue: CMARK_NODE_CUSTOM_INLINE.rawValue)
+    public static let customInline = CMNodeType(rawValue: CMARK_NODE_CUSTOM_INLINE.rawValue)
 
     /// The inline emphasis node type.
-    static let emphasis = CMNodeType(rawValue: CMARK_NODE_EMPH.rawValue)
+    public static let emphasis = CMNodeType(rawValue: CMARK_NODE_EMPH.rawValue)
 
     /// The inline strong node type.
-    static let strong = CMNodeType(rawValue: CMARK_NODE_STRONG.rawValue)
+    public static let strong = CMNodeType(rawValue: CMARK_NODE_STRONG.rawValue)
 
     /// The inline link node type.
-    static let link = CMNodeType(rawValue: CMARK_NODE_LINK.rawValue)
+    public static let link = CMNodeType(rawValue: CMARK_NODE_LINK.rawValue)
 
     /// The inline image node type.
-    static let image = CMNodeType(rawValue: CMARK_NODE_IMAGE.rawValue)
+    public static let image = CMNodeType(rawValue: CMARK_NODE_IMAGE.rawValue)
 
     /// The inline footnote reference node type.
-    static let footnoteReference = CMNodeType(rawValue: CMARK_NODE_FOOTNOTE_REFERENCE.rawValue)
+    public static let footnoteReference = CMNodeType(rawValue: CMARK_NODE_FOOTNOTE_REFERENCE.rawValue)
 
     /// Equatable implementation.
     public static func == (lhs: CMNodeType, rhs: CMNodeType) -> Bool {

--- a/Tests/MaakuTests/CMark/CMDocumentSpec.swift
+++ b/Tests/MaakuTests/CMark/CMDocumentSpec.swift
@@ -147,6 +147,36 @@ Hello, this is a simple markdown document with one paragraph.
                 }
             }
         }
+
+        describe("document node") {
+            it("exists even with an empty document") {
+                do {
+                    let document = try CMDocument(text: "")
+                    expect(document.node.type).to(equal(CMNodeType.document))
+                } catch let error {
+                    it("fails to initialize empty document") {
+                        fail("\(error.localizedDescription)")
+                    }
+                }
+            }
+            it("is the main node for a complex document") {
+                do {
+                    let markdown = """
+# Heading 1
+## Heading 2
+Simple paragraph
+
+Another Paragraph
+"""
+                    let document = try CMDocument(text: markdown)
+                    expect(document.node.type).to(equal(CMNodeType.document))
+                } catch let error {
+                    it("fails to return reasonable node types") {
+                        fail("\(error.localizedDescription)")
+                    }
+                }
+            }
+        }
     }
 
 }

--- a/Tests/MaakuTests/CMark/CMDocumentSpec.swift
+++ b/Tests/MaakuTests/CMark/CMDocumentSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Container/BlockQuoteSpec.swift
+++ b/Tests/MaakuTests/Core/Container/BlockQuoteSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Container/FootnoteDefinitionSpec.swift
+++ b/Tests/MaakuTests/Core/Container/FootnoteDefinitionSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Container/ListItemSpec.swift
+++ b/Tests/MaakuTests/Core/Container/ListItemSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Container/OrderedListSpec.swift
+++ b/Tests/MaakuTests/Core/Container/OrderedListSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Container/UnorderedListSpec.swift
+++ b/Tests/MaakuTests/Core/Container/UnorderedListSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/DocumentSpec.swift
+++ b/Tests/MaakuTests/Core/DocumentSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Extensions/AutolinkSpec.swift
+++ b/Tests/MaakuTests/Core/Extensions/AutolinkSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Extensions/StrikethroughSpec.swift
+++ b/Tests/MaakuTests/Core/Extensions/StrikethroughSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Extensions/TableSpec.swift
+++ b/Tests/MaakuTests/Core/Extensions/TableSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Extensions/TagFilterSpec.swift
+++ b/Tests/MaakuTests/Core/Extensions/TagFilterSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/EmphasisSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/EmphasisSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/FootnoteReferenceSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/FootnoteReferenceSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/ImageSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/ImageSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/InlineCodeSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/InlineCodeSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/InlineHtmlSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/InlineHtmlSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/LineBreakSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/LineBreakSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/LinkSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/LinkSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/SoftBreakSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/SoftBreakSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/StrongSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/StrongSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Inline/TextSpec.swift
+++ b/Tests/MaakuTests/Core/Inline/TextSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Leaf/CodeBlockSpec.swift
+++ b/Tests/MaakuTests/Core/Leaf/CodeBlockSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Leaf/HeadingSpec.swift
+++ b/Tests/MaakuTests/Core/Leaf/HeadingSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Leaf/HorizontalRuleSpec.swift
+++ b/Tests/MaakuTests/Core/Leaf/HorizontalRuleSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Leaf/HtmlBlockSpec.swift
+++ b/Tests/MaakuTests/Core/Leaf/HtmlBlockSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/Leaf/ParagraphSpec.swift
+++ b/Tests/MaakuTests/Core/Leaf/ParagraphSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Core/StyleSpec.swift
+++ b/Tests/MaakuTests/Core/StyleSpec.swift
@@ -16,7 +16,7 @@
     public typealias Color = UIColor
 #endif
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest

--- a/Tests/MaakuTests/Plugins/YoutubePluginSpec.swift
+++ b/Tests/MaakuTests/Plugins/YoutubePluginSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
-@testable import Maaku
+import Maaku
 import Nimble
 import Quick
 import XCTest


### PR DESCRIPTION
The makes the CMNodeType values public so that they are accessible by users of the API, not just by the code in the library.
Fixes issue #22 