### PR TITLE
Consolidate literal getter. Adds `stringContent` for CMNode

### DIFF
--- a/Sources/Maaku/CMark/CMNode.swift
+++ b/Sources/Maaku/CMark/CMNode.swift
@@ -95,9 +95,14 @@ public extension CMNode {
         return String(cString: buffer)
     }
 
-    /// The string value.
+    /// The string value (literal).
     public var stringValue: String? {
-        guard let buffer = cmark_node_get_literal(cmarkNode) else {
+        return literal
+    }
+
+    /// The string content value.
+    public var stringContent: String? {
+        guard let buffer = cmark_node_get_string_content(cmarkNode) else {
             return nil
         }
 


### PR DESCRIPTION
- The `stringValue` and `literal` shares the same implementation.
   `stringValue` is a convenient getter
- Adds the missing `stringContent` for the CMNode