### PR TITLE
Make CMNodeType an enum type

### DIFF
--- a/Sources/Maaku/CMark/CMNodeType.swift
+++ b/Sources/Maaku/CMark/CMNodeType.swift
@@ -2,7 +2,7 @@
 //  CMNodeType.swift
 //  Maaku
 //
-//  Created by Kris Baker on 12/20/17.
+//  Created by Honghao Zhang on 4/22/19.
 //  Copyright © 2017 Kristopher Baker. All rights reserved.
 //
 
@@ -10,79 +10,139 @@ import Foundation
 import libcmark_gfm
 
 /// Represents a cmark node type.
-public struct CMNodeType: Equatable {
+public enum CMNodeType: Equatable {
+    case none
+    case document
+    case blockQuote
+    case list
+    case item
+    case codeBlock
+    case htmlBlock
+    case customBlock
+    case paragraph
+    case heading
+    case thematicBreak
+    case footnoteDefinition
+    case text
+    case softBreak
+    case lineBreak
+    case code
+    case htmlInline
+    case customInline
+    case emphasis
+    case strong
+    case link
+    case image
+    case footnoteReference
+    case `extension`(UInt32)
 
     /// The raw value.
-    let rawValue: UInt32
+    var rawValue: UInt32 {
+        switch self {
+        case .none:
+            return CMARK_NODE_NONE.rawValue
+        case .document:
+            return CMARK_NODE_DOCUMENT.rawValue
+        case .blockQuote:
+            return CMARK_NODE_BLOCK_QUOTE.rawValue
+        case .list:
+            return CMARK_NODE_LIST.rawValue
+        case .item:
+            return CMARK_NODE_ITEM.rawValue
+        case .codeBlock:
+            return CMARK_NODE_CODE_BLOCK.rawValue
+        case .htmlBlock:
+            return CMARK_NODE_HTML_BLOCK.rawValue
+        case .customBlock:
+            return CMARK_NODE_CUSTOM_BLOCK.rawValue
+        case .paragraph:
+            return CMARK_NODE_PARAGRAPH.rawValue
+        case .heading:
+            return CMARK_NODE_HEADING.rawValue
+        case .thematicBreak:
+            return CMARK_NODE_THEMATIC_BREAK.rawValue
+        case .footnoteDefinition:
+            return CMARK_NODE_FOOTNOTE_DEFINITION.rawValue
+        case .text:
+            return CMARK_NODE_TEXT.rawValue
+        case .softBreak:
+            return CMARK_NODE_SOFTBREAK.rawValue
+        case .lineBreak:
+            return CMARK_NODE_LINEBREAK.rawValue
+        case .code:
+            return CMARK_NODE_CODE.rawValue
+        case .htmlInline:
+            return CMARK_NODE_HTML_INLINE.rawValue
+        case .customInline:
+            return CMARK_NODE_CUSTOM_INLINE.rawValue
+        case .emphasis:
+            return CMARK_NODE_EMPH.rawValue
+        case .strong:
+            return CMARK_NODE_STRONG.rawValue
+        case .link:
+            return CMARK_NODE_LINK.rawValue
+        case .image:
+            return CMARK_NODE_IMAGE.rawValue
+        case .footnoteReference:
+            return CMARK_NODE_FOOTNOTE_REFERENCE.rawValue
+        case let .`extension`(rawValue):
+            return rawValue
+        }
+    }
 
-    /// The none node type.
-    public static let none = CMNodeType(rawValue: CMARK_NODE_NONE.rawValue)
-
-    /// The document node type.
-    public static let document = CMNodeType(rawValue: CMARK_NODE_DOCUMENT.rawValue)
-
-    /// The blockquote node type.
-    public static let blockQuote = CMNodeType(rawValue: CMARK_NODE_BLOCK_QUOTE.rawValue)
-
-    /// The list node type.
-    public static let list = CMNodeType(rawValue: CMARK_NODE_LIST.rawValue)
-
-    /// The list item node type.
-    public static let item = CMNodeType(rawValue: CMARK_NODE_ITEM.rawValue)
-
-    /// The code block node type.
-    public static let codeBlock = CMNodeType(rawValue: CMARK_NODE_CODE_BLOCK.rawValue)
-
-    /// The HTML block node type.
-    public static let htmlBlock = CMNodeType(rawValue: CMARK_NODE_HTML_BLOCK.rawValue)
-
-    /// The custom block node type.
-    public static let customBlock = CMNodeType(rawValue: CMARK_NODE_CUSTOM_BLOCK.rawValue)
-
-    /// The paragraph node type.
-    public static let paragraph = CMNodeType(rawValue: CMARK_NODE_PARAGRAPH.rawValue)
-
-    /// The heading node type.
-    public static let heading = CMNodeType(rawValue: CMARK_NODE_HEADING.rawValue)
-
-    /// The thematic break (horizontal rule) node type.
-    public static let thematicBreak = CMNodeType(rawValue: CMARK_NODE_THEMATIC_BREAK.rawValue)
-
-    /// The footnote definition node type.
-    public static let footnoteDefinition = CMNodeType(rawValue: CMARK_NODE_FOOTNOTE_DEFINITION.rawValue)
-
-    /// The text node type.
-    public static let text = CMNodeType(rawValue: CMARK_NODE_TEXT.rawValue)
-
-    /// The soft break node type.
-    public static let softBreak = CMNodeType(rawValue: CMARK_NODE_SOFTBREAK.rawValue)
-
-    /// The line break node type.
-    public static let lineBreak = CMNodeType(rawValue: CMARK_NODE_LINEBREAK.rawValue)
-
-    /// The inline code node type.
-    public static let code = CMNodeType(rawValue: CMARK_NODE_CODE.rawValue)
-
-    /// The inline HTML node type.
-    public static let htmlInline = CMNodeType(rawValue: CMARK_NODE_HTML_INLINE.rawValue)
-
-    /// The inline custom node type.
-    public static let customInline = CMNodeType(rawValue: CMARK_NODE_CUSTOM_INLINE.rawValue)
-
-    /// The inline emphasis node type.
-    public static let emphasis = CMNodeType(rawValue: CMARK_NODE_EMPH.rawValue)
-
-    /// The inline strong node type.
-    public static let strong = CMNodeType(rawValue: CMARK_NODE_STRONG.rawValue)
-
-    /// The inline link node type.
-    public static let link = CMNodeType(rawValue: CMARK_NODE_LINK.rawValue)
-
-    /// The inline image node type.
-    public static let image = CMNodeType(rawValue: CMARK_NODE_IMAGE.rawValue)
-
-    /// The inline footnote reference node type.
-    public static let footnoteReference = CMNodeType(rawValue: CMARK_NODE_FOOTNOTE_REFERENCE.rawValue)
+    // swiftlint:disable cyclomatic_complexity function_body_length
+    init(rawValue: UInt32) {
+        switch rawValue {
+        case CMARK_NODE_NONE.rawValue:
+            self = .none
+        case CMARK_NODE_DOCUMENT.rawValue:
+            self = .document
+        case CMARK_NODE_BLOCK_QUOTE.rawValue:
+            self = .blockQuote
+        case CMARK_NODE_LIST.rawValue:
+            self = .list
+        case CMARK_NODE_ITEM.rawValue:
+            self = .item
+        case CMARK_NODE_CODE_BLOCK.rawValue:
+            self = .codeBlock
+        case CMARK_NODE_HTML_BLOCK.rawValue:
+            self = .htmlBlock
+        case CMARK_NODE_CUSTOM_BLOCK.rawValue:
+            self = .customBlock
+        case CMARK_NODE_PARAGRAPH.rawValue:
+            self = .paragraph
+        case CMARK_NODE_HEADING.rawValue:
+            self = .heading
+        case CMARK_NODE_THEMATIC_BREAK.rawValue:
+            self = .thematicBreak
+        case CMARK_NODE_FOOTNOTE_DEFINITION.rawValue:
+            self = .footnoteDefinition
+        case CMARK_NODE_TEXT.rawValue:
+            self = .text
+        case CMARK_NODE_SOFTBREAK.rawValue:
+            self = .softBreak
+        case CMARK_NODE_LINEBREAK.rawValue:
+            self = .lineBreak
+        case CMARK_NODE_CODE.rawValue:
+            self = .code
+        case CMARK_NODE_HTML_INLINE.rawValue:
+            self = .htmlInline
+        case CMARK_NODE_CUSTOM_INLINE.rawValue:
+            self = .customInline
+        case CMARK_NODE_EMPH.rawValue:
+            self = .emphasis
+        case CMARK_NODE_STRONG.rawValue:
+            self = .strong
+        case CMARK_NODE_LINK.rawValue:
+            self = .link
+        case CMARK_NODE_IMAGE.rawValue:
+            self = .image
+        case CMARK_NODE_FOOTNOTE_REFERENCE.rawValue:
+            self = .footnoteReference
+        default:
+            self = .`extension`(rawValue)
+        }
+    }
 
     /// Equatable implementation.
     public static func == (lhs: CMNodeType, rhs: CMNodeType) -> Bool {

--- a/Sources/Maaku/CMark/CMNodeType.swift
+++ b/Sources/Maaku/CMark/CMNodeType.swift
@@ -9,6 +9,46 @@
 import Foundation
 import libcmark_gfm
 
+public enum CMNodeExtensionType {
+    case strikethrough
+    case table
+    case tableRow
+    case tableCell
+    case other(UInt32)
+
+    public var rawValue: UInt32 {
+        switch self {
+        case .strikethrough:
+            return CMARK_NODE_STRIKETHROUGH.rawValue
+        case .table:
+            return CMARK_NODE_TABLE.rawValue
+        case .tableRow:
+            return CMARK_NODE_TABLE_ROW.rawValue
+        case .tableCell:
+            return CMARK_NODE_TABLE_CELL.rawValue
+        case let .other(rawValue):
+            return rawValue
+        }
+    }
+
+    init(rawValue: UInt32) {
+        switch rawValue {
+        case CMARK_NODE_STRIKETHROUGH.rawValue:
+            self = .strikethrough
+        case CMARK_NODE_TABLE.rawValue:
+            self = .table
+        case CMARK_NODE_TABLE_ROW.rawValue:
+            self = .tableRow
+        case CMARK_NODE_TABLE_CELL.rawValue:
+            self = .tableCell
+        case CMARK_NODE_TABLE_ROW.rawValue:
+            self = .tableRow
+        default:
+            self = .other(rawValue)
+        }
+    }
+}
+
 /// Represents a cmark node type.
 public enum CMNodeType: Equatable {
     case none
@@ -34,7 +74,7 @@ public enum CMNodeType: Equatable {
     case link
     case image
     case footnoteReference
-    case `extension`(UInt32)
+    case `extension`(CMNodeExtensionType)
 
     /// The raw value.
     var rawValue: UInt32 {
@@ -85,8 +125,8 @@ public enum CMNodeType: Equatable {
             return CMARK_NODE_IMAGE.rawValue
         case .footnoteReference:
             return CMARK_NODE_FOOTNOTE_REFERENCE.rawValue
-        case let .`extension`(rawValue):
-            return rawValue
+        case let .extension(type):
+            return type.rawValue
         }
     }
 
@@ -140,7 +180,7 @@ public enum CMNodeType: Equatable {
         case CMARK_NODE_FOOTNOTE_REFERENCE.rawValue:
             self = .footnoteReference
         default:
-            self = .`extension`(rawValue)
+            self = .extension(CMNodeExtensionType(rawValue: rawValue))
         }
     }
 

--- a/Sources/Maaku/CMark/CMNodeType.swift
+++ b/Sources/Maaku/CMark/CMNodeType.swift
@@ -9,14 +9,16 @@
 import Foundation
 import libcmark_gfm
 
-public enum CMNodeExtensionType {
+/// Represents a cmark extension node type.
+public enum CMNodeExtensionType: Equatable {
     case strikethrough
     case table
     case tableRow
     case tableCell
     case other(UInt32)
 
-    public var rawValue: UInt32 {
+    /// The raw value.
+    var rawValue: UInt32 {
         switch self {
         case .strikethrough:
             return CMARK_NODE_STRIKETHROUGH.rawValue
@@ -46,6 +48,11 @@ public enum CMNodeExtensionType {
         default:
             self = .other(rawValue)
         }
+    }
+
+    /// Equatable implementation.
+    public static func == (lhs: CMNodeExtensionType, rhs: CMNodeExtensionType) -> Bool {
+        return lhs.rawValue == rhs.rawValue
     }
 }
 

--- a/Sources/Maaku/CMark/CMParser.swift
+++ b/Sources/Maaku/CMark/CMParser.swift
@@ -446,6 +446,8 @@ public class CMParser {
         }
 
         switch node.type {
+        case .none:
+            return
         case .document:
             if eventType == .enter {
                 delegate?.parserDidStartDocument(parser: self)
@@ -560,7 +562,7 @@ public class CMParser {
             if eventType == .enter {
                 delegate?.parser(parser: self, foundFootnoteReference: node.stringValue ?? "")
             }
-        default:
+        case .extension(_):
             handleExtensions(node, eventType: eventType)
         }
     }


### PR DESCRIPTION
Making `CMNodeType ` an enum type, which is more convenient to switch on.