### PR TITLE
Extension consolidation

### DIFF
--- a/Maaku.xcodeproj/project.pbxproj
+++ b/Maaku.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		04C93A9D226F89730058589D /* CMExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C93A9B226F89440058589D /* CMExtensionSpec.swift */; };
+		04C93A9E226F89740058589D /* CMExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C93A9B226F89440058589D /* CMExtensionSpec.swift */; };
+		04C93A9F226F89770058589D /* CMExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C93A9B226F89440058589D /* CMExtensionSpec.swift */; };
+		04C93AA1226F8BBA0058589D /* CMExtensionInternalSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C93AA0226F8BBA0058589D /* CMExtensionInternalSpec.swift */; };
+		04C93AA2226F8BBA0058589D /* CMExtensionInternalSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C93AA0226F8BBA0058589D /* CMExtensionInternalSpec.swift */; };
+		04C93AA3226F8BBA0058589D /* CMExtensionInternalSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C93AA0226F8BBA0058589D /* CMExtensionInternalSpec.swift */; };
 		0B6E550F62C9027B9E49B2A7 /* Pods_MaakuTargets_Maaku_watchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E32396AB5ACC2C6CFA9F2AC4 /* Pods_MaakuTargets_Maaku_watchOS.framework */; };
 		4B6D492524092DD01386403F /* Pods_MaakuTargets_Maaku.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 37814D708DBC7FA6C5387968 /* Pods_MaakuTargets_Maaku.framework */; };
 		51EA21CD71E2FD365A10F250 /* Pods_MaakuTargets_Maaku_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC9A961F348AB9BEB396796F /* Pods_MaakuTargets_Maaku_tvOS.framework */; };
@@ -308,6 +314,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		04C93A9B226F89440058589D /* CMExtensionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMExtensionSpec.swift; sourceTree = "<group>"; };
+		04C93AA0226F8BBA0058589D /* CMExtensionInternalSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMExtensionInternalSpec.swift; sourceTree = "<group>"; };
 		086ED2176C071EE0CFD460C6 /* Pods-MaakuTargets-MaakuTestTargets-MaakuMacOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MaakuTargets-MaakuTestTargets-MaakuMacOSTests.release.xcconfig"; path = "Target Support Files/Pods-MaakuTargets-MaakuTestTargets-MaakuMacOSTests/Pods-MaakuTargets-MaakuTestTargets-MaakuMacOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		31AB2CAB0FE87B6227CB154A /* Pods-MaakuTargets-MaakuTestTargets-MaakuTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MaakuTargets-MaakuTestTargets-MaakuTests.debug.xcconfig"; path = "Target Support Files/Pods-MaakuTargets-MaakuTestTargets-MaakuTests/Pods-MaakuTargets-MaakuTestTargets-MaakuTests.debug.xcconfig"; sourceTree = "<group>"; };
 		37814D708DBC7FA6C5387968 /* Pods_MaakuTargets_Maaku.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MaakuTargets_Maaku.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -535,6 +543,8 @@
 			isa = PBXGroup;
 			children = (
 				A254E2B91FEF7F6A00C48E71 /* CMDocumentSpec.swift */,
+				04C93A9B226F89440058589D /* CMExtensionSpec.swift */,
+				04C93AA0226F8BBA0058589D /* CMExtensionInternalSpec.swift */,
 			);
 			path = CMark;
 			sourceTree = "<group>";
@@ -1449,6 +1459,7 @@
 				A28847421FF5890A00558555 /* StyleSpec.swift in Sources */,
 				A254E3121FEF7F9500C48E71 /* StrongSpec.swift in Sources */,
 				A254E2E91FEF7F8800C48E71 /* HtmlBlockSpec.swift in Sources */,
+				04C93A9E226F89740058589D /* CMExtensionSpec.swift in Sources */,
 				A254E30A1FEF7F9500C48E71 /* LineBreakSpec.swift in Sources */,
 				A254E30E1FEF7F9500C48E71 /* InlineCodeSpec.swift in Sources */,
 				A254E2F91FEF7F8E00C48E71 /* AutolinkSpec.swift in Sources */,
@@ -1460,6 +1471,7 @@
 				A254E3111FEF7F9500C48E71 /* InlineHtmlSpec.swift in Sources */,
 				A254E3221FEF7F9C00C48E71 /* OrderedListSpec.swift in Sources */,
 				A254E2FA1FEF7F8E00C48E71 /* StrikethroughSpec.swift in Sources */,
+				04C93AA2226F8BBA0058589D /* CMExtensionInternalSpec.swift in Sources */,
 				A254E2DF1FEF7F7B00C48E71 /* CMDocumentSpec.swift in Sources */,
 				A254E2ED1FEF7F8800C48E71 /* CodeBlockSpec.swift in Sources */,
 				A254E3241FEF7F9C00C48E71 /* ListItemSpec.swift in Sources */,
@@ -1586,6 +1598,7 @@
 				A28847431FF5890A00558555 /* StyleSpec.swift in Sources */,
 				A254E31C1FEF7F9600C48E71 /* StrongSpec.swift in Sources */,
 				A254E2EE1FEF7F8800C48E71 /* HtmlBlockSpec.swift in Sources */,
+				04C93A9F226F89770058589D /* CMExtensionSpec.swift in Sources */,
 				A254E3141FEF7F9600C48E71 /* LineBreakSpec.swift in Sources */,
 				A254E3181FEF7F9600C48E71 /* InlineCodeSpec.swift in Sources */,
 				A254E2FD1FEF7F8F00C48E71 /* AutolinkSpec.swift in Sources */,
@@ -1597,6 +1610,7 @@
 				A254E31B1FEF7F9600C48E71 /* InlineHtmlSpec.swift in Sources */,
 				A254E3271FEF7F9D00C48E71 /* OrderedListSpec.swift in Sources */,
 				A254E2FE1FEF7F8F00C48E71 /* StrikethroughSpec.swift in Sources */,
+				04C93AA3226F8BBA0058589D /* CMExtensionInternalSpec.swift in Sources */,
 				A254E2E01FEF7F7C00C48E71 /* CMDocumentSpec.swift in Sources */,
 				A254E2F21FEF7F8800C48E71 /* CodeBlockSpec.swift in Sources */,
 				A254E3291FEF7F9D00C48E71 /* ListItemSpec.swift in Sources */,
@@ -1672,6 +1686,7 @@
 				A28847411FF5890A00558555 /* StyleSpec.swift in Sources */,
 				A254E3081FEF7F9400C48E71 /* StrongSpec.swift in Sources */,
 				A254E2E41FEF7F8700C48E71 /* HtmlBlockSpec.swift in Sources */,
+				04C93A9D226F89730058589D /* CMExtensionSpec.swift in Sources */,
 				A254E3001FEF7F9400C48E71 /* LineBreakSpec.swift in Sources */,
 				A254E3041FEF7F9400C48E71 /* InlineCodeSpec.swift in Sources */,
 				A254E2F51FEF7F8D00C48E71 /* AutolinkSpec.swift in Sources */,
@@ -1683,6 +1698,7 @@
 				A254E3071FEF7F9400C48E71 /* InlineHtmlSpec.swift in Sources */,
 				A254E31D1FEF7F9B00C48E71 /* OrderedListSpec.swift in Sources */,
 				A254E2F61FEF7F8D00C48E71 /* StrikethroughSpec.swift in Sources */,
+				04C93AA1226F8BBA0058589D /* CMExtensionInternalSpec.swift in Sources */,
 				A254E2DE1FEF7F7B00C48E71 /* CMDocumentSpec.swift in Sources */,
 				A254E2E81FEF7F8700C48E71 /* CodeBlockSpec.swift in Sources */,
 				A254E31F1FEF7F9B00C48E71 /* ListItemSpec.swift in Sources */,

--- a/Sources/Maaku/CMark/CMDocument.swift
+++ b/Sources/Maaku/CMark/CMDocument.swift
@@ -94,20 +94,20 @@ public class CMDocument {
             cmark_parser_free(parser)
         }
 
-        if extensions.contains(.tables), let tableExtension = cmark_find_syntax_extension("table") {
+        if extensions.contains(.tables), let tableExtension = CMExtensionOption.tables.syntaxExtension {
             cmark_parser_attach_syntax_extension(parser, tableExtension)
         }
 
-        if extensions.contains(.autolinks), let autolinkExtension = cmark_find_syntax_extension("autolink") {
+        if extensions.contains(.autolinks), let autolinkExtension = CMExtensionOption.autolinks.syntaxExtension {
             cmark_parser_attach_syntax_extension(parser, autolinkExtension)
         }
 
         if extensions.contains(.strikethrough),
-            let strikethroughExtension = cmark_find_syntax_extension("strikethrough") {
+            let strikethroughExtension = CMExtensionOption.strikethrough.syntaxExtension {
             cmark_parser_attach_syntax_extension(parser, strikethroughExtension)
         }
 
-        if extensions.contains(.tagfilters), let tagfilterExtension = cmark_find_syntax_extension("tagfilter") {
+        if extensions.contains(.tagfilters), let tagfilterExtension = CMExtensionOption.tagfilters.syntaxExtension {
             cmark_parser_attach_syntax_extension(parser, tagfilterExtension)
         }
 

--- a/Sources/Maaku/CMark/CMDocument.swift
+++ b/Sources/Maaku/CMark/CMDocument.swift
@@ -94,22 +94,7 @@ public class CMDocument {
             cmark_parser_free(parser)
         }
 
-        if extensions.contains(.tables), let tableExtension = CMExtensionOption.tables.syntaxExtension {
-            cmark_parser_attach_syntax_extension(parser, tableExtension)
-        }
-
-        if extensions.contains(.autolinks), let autolinkExtension = CMExtensionOption.autolinks.syntaxExtension {
-            cmark_parser_attach_syntax_extension(parser, autolinkExtension)
-        }
-
-        if extensions.contains(.strikethrough),
-            let strikethroughExtension = CMExtensionOption.strikethrough.syntaxExtension {
-            cmark_parser_attach_syntax_extension(parser, strikethroughExtension)
-        }
-
-        if extensions.contains(.tagfilters), let tagfilterExtension = CMExtensionOption.tagfilters.syntaxExtension {
-            cmark_parser_attach_syntax_extension(parser, tagfilterExtension)
-        }
+        try extensions.addToParser(parser)
 
         cmark_parser_feed(parser, text, text.utf8.count)
 

--- a/Sources/Maaku/CMark/CMExtension.swift
+++ b/Sources/Maaku/CMark/CMExtension.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import libcmark_gfm
 
 /// Represents a cmark extension option.
 public struct CMExtensionOption: OptionSet {
@@ -42,4 +43,59 @@ public struct CMExtensionOption: OptionSet {
     /// Tag filters
     public static let tagfilters = CMExtensionOption(rawValue: 8)
 
+    /// Get the extension name associated with this option
+    ///
+    /// - Returns:
+    ///    The name of the extension associated with this option (if there is only one),
+    ///    or nil if there is either no extension associated with this option, or if there
+    ///    are multiple extensions associated with this OptionSet.
+    public var extensionName: String? {
+        switch self {
+        case .tables: return "table"
+        case .autolinks: return "autolink"
+        case .strikethrough: return "strikethrough"
+        case .tagfilters: return "tagfilter"
+        default: return nil
+        }
+    }
+
+    /// Get an option that corresponds to the given extension name
+    ///
+    /// - Parameters:
+    ///    - forExtensionName: the extension name for which we want to find the associated option
+    ///
+    /// - Returns:
+    ///    The option associated with the extension name if any, or nil if the extension isn't supported.
+    public static func option(forExtensionName name: String) -> CMExtensionOption? {
+        switch name {
+        case "table": return tables
+        case "autolink": return autolinks
+        case "strikethrough": return strikethrough
+        case "tagfilter": return tagfilters
+        default: return none
+        }
+    }
+
+    /// Return the underlying syntax extension object associated with the given extension
+    ///
+    /// - Returns:
+    ///    The underlying (internal) syntax extension object associated with the given extension or
+    ///    nil if none is found.
+    ///
+    /// XXX Note that this is currently not exposed to the users of the library, as it really deals
+    /// with internal structures and probably isn't of much use to them. The users of the library can always
+    /// get this info themselves if they really want it.
+    var syntaxExtension: UnsafeMutablePointer<cmark_syntax_extension>? {
+        guard let name = extensionName else {
+            // If we couldn't get the extension name, then we can't get the extension
+            return nil
+        }
+
+        if name.isEmpty {
+            // If the name is empty, then it isn't an extension name.
+            return nil
+        } else {
+            return cmark_find_syntax_extension(name)
+       }
+    }
 }

--- a/Sources/Maaku/CMark/CMNode.swift
+++ b/Sources/Maaku/CMark/CMNode.swift
@@ -222,6 +222,21 @@ public extension CMNode {
         return Iterator(node: self)
     }
 
+    /// Returns the extension associated with the node, or nil
+    /// if no extension. Should only ever return a single extension option value,
+    /// as a node can never be associated with multiple extensions
+    public var `extension`: CMExtensionOption? {
+        guard let ext = cmark_node_get_syntax_extension(cmarkNode) else {
+            return nil
+        }
+        let extName = String(cString: ext.pointee.name)
+        let result = CMExtensionOption.option(forExtensionName: extName)
+        if result == .none {
+            return nil
+        } else {
+            return result
+        }
+    }
 }
 
 /// Node rendering methods

--- a/Tests/MaakuTests/CMark/CMDocumentSpec.swift
+++ b/Tests/MaakuTests/CMark/CMDocumentSpec.swift
@@ -124,7 +124,7 @@ Hello, this is a simple markdown document with one paragraph.
 """
                     let document = try CMDocument(text: markdown)
                     let latex = try document.renderLatex(width: 100)
-                    // swiftlint:disable line_length
+                    // swiftlint:disable:next line_length
                     expect(latex).to(equal("\\begin{quote}\nThis is a blockquote with two paragraphs. Lorem ipsum dolor sit amet, consectetuer adipiscing elit.\nAliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae,\nrisus.\n\nDonec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse id sem consectetuer libero\nluctus adipiscing.\n\n\\end{quote}\n"))
                 } catch let error {
                     it("fails to initialize the document") {
@@ -175,6 +175,13 @@ Another Paragraph
                         fail("\(error.localizedDescription)")
                     }
                 }
+            }
+        }
+
+        describe("Invalid extension options") {
+            it("throws an exception with invalid extension types.") {
+                // swiftlint:disable:next line_length
+                expect { try CMDocument(text: "my text", options: .default, extensions: CMExtensionOption(rawValue: Int32.max)) }.to(throwError(CMDocumentError.parsingError))
             }
         }
     }

--- a/Tests/MaakuTests/CMark/CMExtensionInternalSpec.swift
+++ b/Tests/MaakuTests/CMark/CMExtensionInternalSpec.swift
@@ -1,0 +1,137 @@
+//
+//  CMExtensionInternalSpec.swift
+//  Maaku
+//
+//  Created by Tim Learmont on 4/23/19.
+//  Copyright © 2019 Kristopher Baker. All rights reserved.
+//
+
+// Include testable Maaku & libcmark_gfm, since we're testing things that aren't visible to user.
+import libcmark_gfm
+@testable import Maaku
+import Nimble
+import Quick
+import XCTest
+
+/// Test internal portions of the CMExtensionOption stuff
+class CMExtensionInternalSpec: QuickSpec {
+
+    // swiftlint:disable function_body_length
+    override func spec() {
+        describe("CMExtensionOption basics") {
+            it("has all extensions registered") {
+                expect(CMExtensionOption.autolinks.syntaxExtension).toNot(beNil())
+                expect(CMExtensionOption.strikethrough.syntaxExtension).toNot(beNil())
+                expect(CMExtensionOption.tables.syntaxExtension).toNot(beNil())
+                expect(CMExtensionOption.tagfilters.syntaxExtension).toNot(beNil())
+            }
+        }
+        describe("Complex document") {
+            let markdown = """
+www.github.com
+
+This should be converted to non-HTML: <title>
+
+|Name|Pay|
+|----|---|
+|K   |100|
+|H   | 50|
+|T   | 25|
+
+~~text with strike~~
+
+- item
+- [ ] task item
+"""
+            it("doesn't have nodes with extensions if no extensions enabled") {
+                let noExtensionKey = ""
+                do {
+                    let document = try CMDocument(text: markdown, options: [], extensions: .none)
+                    var nodesByExtension: [String: [CMNode]] = [:]
+                    try document.node.iterator?.enumerate { node, event in
+                        guard event == .enter else {
+                            return false
+                        }
+
+                        var name: String
+                        if cmark_node_get_syntax_extension(node.cmarkNode) != nil {
+                            // There is an extension associated with this node.
+                            // swiftlint:disable:next line_length
+                            expect(node.extension?.syntaxExtension).to(equal(cmark_node_get_syntax_extension(node.cmarkNode)))
+                            expect(node.extension?.extensionName).toNot(beNil())
+                            name = node.extension!.extensionName!
+                        } else {
+                            name = noExtensionKey
+                            expect(node.extension).to(beNil())
+                        }
+                        // Add the node to the dictionary
+                        var foundNodes = nodesByExtension[name] ?? []
+                        foundNodes.append(node)
+                        nodesByExtension[name] = foundNodes
+                        return false
+                    }
+                    // We expect that there are no extension nodes, so all nodes should be
+                    // with the noExtensionKey, thus there should only be one key
+                    // in the dictionary.
+                    expect(nodesByExtension.keys.count).to(equal(1))
+                    expect(nodesByExtension[noExtensionKey]).toNot(beNil())
+                } catch let error {
+                    it("fails to process document") {
+                        fail("\(error.localizedDescription)")
+                    }
+                }
+            }
+            it("has nodes with extensions") {
+                do {
+                    let document = try CMDocument(text: markdown, options: [], extensions: .all)
+                    var nodesByExtension: [String: [CMNode]] = [:]
+                    try document.node.iterator?.enumerate { node, event in
+                        guard event == .enter else {
+                            return false
+                        }
+
+                        var name = ""
+                        if cmark_node_get_syntax_extension(node.cmarkNode) != nil {
+                            // There is an extension associated with this node.
+                            // swiftlint:disable:next line_length
+                            expect(node.extension?.syntaxExtension).to(equal(cmark_node_get_syntax_extension(node.cmarkNode)))
+                            expect(node.extension?.extensionName).toNot(beNil())
+                            name = node.extension!.extensionName!
+                            print("Node at \(node.startLine):\(node.startColumn) \(node.humanReadableType ?? "")")
+                        } else {
+                            expect(node.extension).to(beNil())
+                        }
+                        // Add the node to the dictionary
+                        var foundNodes = nodesByExtension[name] ?? []
+                        foundNodes.append(node)
+                        nodesByExtension[name] = foundNodes
+                        return false
+                    }
+                    // We expect that we've found some nodes of each extension type.
+                    // swiftlink:disable line_length
+                    
+                    // The autolink extension doesn't add new node types, it just
+                    // converts more things to links.
+                    expect(nodesByExtension[CMExtensionOption.autolinks.extensionName!]).to(beNil())
+                    
+                    // We expect that strikethrough objects were found.
+                    expect(nodesByExtension[CMExtensionOption.strikethrough.extensionName!]).toNot(beNil())
+
+                    // We expect that table extension objects were found
+                    expect(nodesByExtension[CMExtensionOption.tables.extensionName!]).toNot(beNil())
+                    
+                    // tagfilters doesn't add new types, it just changes some values
+                    expect(nodesByExtension[CMExtensionOption.tagfilters.extensionName!]).to(beNil())
+                    // TODO: test tagfilters.
+                    // I'm not sure how to test node object stuff.
+
+                    // swiftlink:enable line_length
+                } catch let error {
+                    it("fails to process document") {
+                        fail("\(error.localizedDescription)")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/MaakuTests/CMark/CMExtensionSpec.swift
+++ b/Tests/MaakuTests/CMark/CMExtensionSpec.swift
@@ -1,0 +1,153 @@
+//
+//  CMExtensionSpec.swift
+//  Maaku
+//
+//  Created by Tim Learmont on 4/23/19.
+//  Copyright © 2019 Kristopher Baker. All rights reserved.
+//
+
+import Maaku
+import Nimble
+import Quick
+import XCTest
+
+class CMExtensionSpec: QuickSpec {
+
+    // swiftlint:disable function_body_length
+    override func spec() {
+        describe("CMExtensionOption basics") {
+            it("should have extension names match extension objects") {
+                // We expect that each of the basic values maps correctly between extension name
+                // and extension type.
+                // swiftlint:disable line_length
+                expect(CMExtensionOption.autolinks).to(equal(CMExtensionOption.option(forExtensionName: CMExtensionOption.autolinks.extensionName ?? "")))
+                expect(CMExtensionOption.strikethrough).to(equal(CMExtensionOption.option(forExtensionName: CMExtensionOption.strikethrough.extensionName ?? "")))
+                expect(CMExtensionOption.tables).to(equal(CMExtensionOption.option(forExtensionName: CMExtensionOption.tables.extensionName ?? "")))
+               expect(CMExtensionOption.tagfilters).to(equal(CMExtensionOption.option(forExtensionName: CMExtensionOption.tagfilters.extensionName ?? "")))
+                // swiftlint:enable line_length
+            }
+        }
+        describe("CMExtensionOption") {
+            let markdown = """
+www.github.com
+
+This should be converted to non-HTML via extensions: <title>
+
+|Name|Pay|
+|----|---|
+|K   |100|
+|H   | 50|
+|T   | 25|
+
+~~text with strike~~
+
+- item
+- [ ] task item
+"""
+            it("doesn't have nodes with extensions if no extensions enabled") {
+                do {
+                    let document = try CMDocument(text: markdown, options: [], extensions: .none)
+                    var nodesByExtension: [Int32: [CMNode]] = [:]
+                    var typesFound: Set<String> = []
+                    try document.node.iterator?.enumerate { node, event in
+                        guard event == .enter else {
+                            return false
+                        }
+
+                        if let typeName = node.humanReadableType {
+                            typesFound.insert(typeName)
+                        }
+
+                        var key = CMExtensionOption.none.rawValue
+                        if let extensionType = node.extension {
+                            key = extensionType.rawValue
+                        }
+                        // Add the node to the dictionary
+                        var foundNodes = nodesByExtension[key] ?? []
+                        foundNodes.append(node)
+                        nodesByExtension[key] = foundNodes
+                        return false
+                    }
+                    // We expect that there are no extension nodes, so all nodes should be
+                    // with the noExtensionKey, thus there should only be one key
+                    // in the dictionary.
+                    expect(nodesByExtension.keys.count).to(equal(1))
+                    expect(nodesByExtension[CMExtensionOption.none.rawValue]).toNot(beNil())
+                    // We expect that none of the extension types are found.
+                    // There shouldn't be a link, because 'autolink' extension wasn't enabled.
+                    expect(typesFound).toNot(contain("link"))
+                    // There shouldn't be strikethroughs, since that extension wasn't enabled.
+                    expect(typesFound).toNot(contain("strikethrough"))
+                    // There shouldn't be table objects, since that extension wasn't enabled.
+                    expect(typesFound).toNot(contain("table_cell"))
+                    expect(typesFound).toNot(contain("table_row"))
+                    expect(typesFound).toNot(contain("table_header"))
+                    expect(typesFound).toNot(contain("table"))
+               } catch let error {
+                    it("fails to process document") {
+                        fail("\(error.localizedDescription)")
+                    }
+                }
+            }
+            it("has nodes with extensions") {
+                do {
+                    let document = try CMDocument(text: markdown, options: [], extensions: .all)
+                    var nodesByExtension: [Int32: [CMNode]] = [:]
+                    var typesFound: Set<String> = []
+                    try document.node.iterator?.enumerate { node, event in
+                        guard event == .enter else {
+                            return false
+                        }
+                        if let typeName = node.humanReadableType {
+                            typesFound.insert(typeName)
+                        }
+
+                        var key = CMExtensionOption.none.rawValue
+                        if let extensionType = node.extension {
+                            // There is an extension associated with this node.
+                            expect(extensionType.extensionName).toNot(beNil())
+                            key = extensionType.rawValue
+                        }
+                        // Add the node to the dictionary
+                        var foundNodes = nodesByExtension[key] ?? []
+                        foundNodes.append(node)
+                        nodesByExtension[key] = foundNodes
+                        return false
+                    }
+                    // We expect that we've found some nodes of each extension type.
+                    // swiftlink:disable line_length
+
+                    // The autolink extension doesn't add new node types, it just
+                    // converts more things to links.
+                    expect(nodesByExtension[CMExtensionOption.autolinks.rawValue]).to(beNil())
+                    // We expect to find a link (converted via autolink)
+                    expect(typesFound).to(contain("link"))
+
+                    // We expect that strikethrough objects were found.
+                    expect(nodesByExtension[CMExtensionOption.strikethrough.rawValue]).toNot(beNil())
+                    // We expect node objects of type "strikethrough"
+                    expect(typesFound).to(contain("strikethrough"))
+
+                    // We expect that table extension objects were found
+                    expect(nodesByExtension[CMExtensionOption.tables.rawValue]).toNot(beNil())
+                    // We expect node objects of all these types:
+                    expect(typesFound).to(contain("table_cell", "table_row", "table_header", "table"))
+
+                    // tagfilters doesn't add new types, it just changes some values
+                    expect(nodesByExtension[CMExtensionOption.tagfilters.rawValue]).to(beNil())
+                    // TODO: test tagfilters.
+                    // I'm not sure how to test node object stuff.
+
+                    // Sinde the tasklist extension is included (yet) we expect that
+                    // the tasklist type wasn't found.
+                    expect(typesFound).toNot(contain("tasklist"))
+                    // swiftlink:enable line_length
+                } catch let error {
+                    it("fails to process document") {
+                        fail("\(error.localizedDescription)")
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I'm working on adding the tasklist extension, but it's not quite ready yet. However, as part of the work, I moved all the extension handling stuff to the CMExtensionOption class, so that if any new extension stuff changes, it's all handled in one place.

Specifically, the CMDocument code doesn't have to worry at all about any extension changes, and the extension information is now available to CMNode if the user wants to query to see what extension is associated with the node.