### PR TITLE
Change "parsing" so that it can work on any node, not just the entire…

### DIFF
--- a/Maaku.xcodeproj/project.pbxproj
+++ b/Maaku.xcodeproj/project.pbxproj
@@ -29,6 +29,9 @@
 		04C2EF4D2297251700413346 /* CMParserSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C2EF4B229724D900413346 /* CMParserSpec.swift */; };
 		04C2EF4E2297251800413346 /* CMParserSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C2EF4B229724D900413346 /* CMParserSpec.swift */; };
 		04C2EF4F2297251B00413346 /* CMParserSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C2EF4B229724D900413346 /* CMParserSpec.swift */; };
+		04C2EF512299E40D00413346 /* DocumentConverterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C2EF502299E40D00413346 /* DocumentConverterSpec.swift */; };
+		04C2EF522299E40D00413346 /* DocumentConverterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C2EF502299E40D00413346 /* DocumentConverterSpec.swift */; };
+		04C2EF532299E40D00413346 /* DocumentConverterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C2EF502299E40D00413346 /* DocumentConverterSpec.swift */; };
 		04C93A9D226F89730058589D /* CMExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C93A9B226F89440058589D /* CMExtensionSpec.swift */; };
 		04C93A9E226F89740058589D /* CMExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C93A9B226F89440058589D /* CMExtensionSpec.swift */; };
 		04C93A9F226F89770058589D /* CMExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C93A9B226F89440058589D /* CMExtensionSpec.swift */; };
@@ -354,6 +357,7 @@
 		0453B99822760CFA00AB31CC /* TasklistItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TasklistItem.swift; sourceTree = "<group>"; };
 		0453B9A022763BAA00AB31CC /* TasklistItemSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TasklistItemSpec.swift; sourceTree = "<group>"; };
 		04C2EF4B229724D900413346 /* CMParserSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMParserSpec.swift; sourceTree = "<group>"; };
+		04C2EF502299E40D00413346 /* DocumentConverterSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentConverterSpec.swift; sourceTree = "<group>"; };
 		04C93A9B226F89440058589D /* CMExtensionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMExtensionSpec.swift; sourceTree = "<group>"; };
 		04C93AA0226F8BBA0058589D /* CMExtensionInternalSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMExtensionInternalSpec.swift; sourceTree = "<group>"; };
 		04CB42CD2273FC3B0006625E /* CMNodeInternal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CMNodeInternal.swift; sourceTree = "<group>"; };
@@ -601,6 +605,7 @@
 			isa = PBXGroup;
 			children = (
 				A254E2BB1FEF7F6A00C48E71 /* DocumentSpec.swift */,
+				04C2EF502299E40D00413346 /* DocumentConverterSpec.swift */,
 				A28847401FF5890A00558555 /* StyleSpec.swift */,
 				A254E2D21FEF7F6A00C48E71 /* Container */,
 				A254E2C21FEF7F6A00C48E71 /* Extensions */,
@@ -1504,6 +1509,7 @@
 			files = (
 				A254E30B1FEF7F9500C48E71 /* FootnoteReferenceSpec.swift in Sources */,
 				A254E3231FEF7F9C00C48E71 /* UnorderedListSpec.swift in Sources */,
+				04C2EF522299E40D00413346 /* DocumentConverterSpec.swift in Sources */,
 				0453B99622760C4C00AB31CC /* CMNodeSpec.swift in Sources */,
 				A254E2EA1FEF7F8800C48E71 /* ParagraphSpec.swift in Sources */,
 				0453B9A222763BAA00AB31CC /* TasklistItemSpec.swift in Sources */,
@@ -1656,6 +1662,7 @@
 			files = (
 				A254E3151FEF7F9600C48E71 /* FootnoteReferenceSpec.swift in Sources */,
 				A254E3281FEF7F9D00C48E71 /* UnorderedListSpec.swift in Sources */,
+				04C2EF532299E40D00413346 /* DocumentConverterSpec.swift in Sources */,
 				0453B99722760C4C00AB31CC /* CMNodeSpec.swift in Sources */,
 				A254E2EF1FEF7F8800C48E71 /* ParagraphSpec.swift in Sources */,
 				0453B9A322763BAA00AB31CC /* TasklistItemSpec.swift in Sources */,
@@ -1754,6 +1761,7 @@
 			files = (
 				A254E3011FEF7F9400C48E71 /* FootnoteReferenceSpec.swift in Sources */,
 				A254E31E1FEF7F9B00C48E71 /* UnorderedListSpec.swift in Sources */,
+				04C2EF512299E40D00413346 /* DocumentConverterSpec.swift in Sources */,
 				0453B99522760C4C00AB31CC /* CMNodeSpec.swift in Sources */,
 				A254E2E51FEF7F8700C48E71 /* ParagraphSpec.swift in Sources */,
 				0453B9A122763BAA00AB31CC /* TasklistItemSpec.swift in Sources */,

--- a/Sources/Maaku/CMark/CMParser.swift
+++ b/Sources/Maaku/CMark/CMParser.swift
@@ -397,47 +397,45 @@ public class CMParser {
     /// The current footnote index.
     private var footnoteIndex: Int32 = 0
 
-    /// The document.
-    private let document: CMDocument
-
     /// Indicates if the parser is currently parsing.
     private var parsing: Bool = false
 
     /// The delegate.
     public weak var delegate: CMParserDelegate?
 
-    /// Creates a parser for the specified document.
+    /// Creates a parser.
     ///
     /// - Parameters:
-    ///     - document: The document.
-    /// - Returns:
-    ///     The parser for the document.
-    public convenience init(document: CMDocument) {
-        self.init(document: document, delegate: nil)
-    }
-
-    /// Creates a parser for the specified document.
-    ///
-    /// - Parameters:
-    ///     - document: The document.
     ///     - delegate: The delegate.
     /// - Returns:
-    ///     The parser for the document.
-    public init(document: CMDocument, delegate: CMParserDelegate?) {
-        self.document = document
+    ///     The parser.
+    public init(delegate: CMParserDelegate? = nil) {
         self.delegate = delegate
     }
 
     /// Parses the document, calling delegate methods as needed.
     ///
+    /// - Parameters:
+    ///     - document: The document.
     /// - Throws:
     ///     `CMParseError.invalidEventType` if an invalid event type is encountered.
-    public func parse() throws {
-        guard !parsing, let iterator = document.node.iterator else {
+    public func parse(document: CMDocument) throws {
+        try parse(subtree: document.node, startingFootnoteIndex: 0)
+    }
+
+    /// Parses the subtree, calling delegate methods as needed.
+    ///
+    /// - Parameters:
+    ///     - subtree: The subtree to parse.
+    /// - Throws:
+    ///     `CMParseError.invalidEventType` if an invalid event type is encountered.
+    public func parse(subtree: CMNode, startingFootnoteIndex: Int32 = 0) throws {
+        guard !parsing, let iterator = subtree.iterator else {
             throw CMParseError.canNotParse
         }
 
         parsing = true
+        footnoteIndex = startingFootnoteIndex
 
         try iterator.enumerate { [unowned self] (node, eventType) -> Bool in
             try self.handleNode(node, eventType: eventType)
@@ -445,7 +443,6 @@ public class CMParser {
         }
 
         parsing = false
-        footnoteIndex = 0
     }
 
     /// Aborts parsing

--- a/Sources/Maaku/Core/DocumentConverter.swift
+++ b/Sources/Maaku/Core/DocumentConverter.swift
@@ -30,9 +30,21 @@ public class DocumentConverter {
     /// - Returns:
     ///     The converted document.
     public func convert(document: CMDocument) throws -> Document {
+        return Document(items: try convert(cmNode: document.node))
+    }
+
+    /// Converts a single CMNode (and its children) to a Node tree.
+    ///
+    /// - Parameters:
+    ///     - cmNode: The CMNode.
+    /// - Throws:
+    ///     `CMParseError.invalidEventType` if an invalid event type is encountered.
+    /// - Returns:
+    ///     The converted Node.
+    public func convert(cmNode: CMNode) throws -> [Block] {
         nodes = []
-        let parser = CMParser(document: document, delegate: self)
-        try parser.parse()
+        let parser = CMParser(delegate: self)
+        try parser.parse(subtree: cmNode)
 
         var items = [Block]()
 
@@ -42,7 +54,7 @@ public class DocumentConverter {
             }
         }
 
-        return Document(items: items)
+        return items
     }
 
 }

--- a/Tests/MaakuTests/Core/DocumentConverterSpec.swift
+++ b/Tests/MaakuTests/Core/DocumentConverterSpec.swift
@@ -1,0 +1,149 @@
+//
+//  DocumentConverterSpec.swift
+//  Maaku
+//
+//  Created by Tim Learmont on 5/25/19.
+//  Copyright © 2019 Kristopher Baker. All rights reserved.
+//
+
+import Maaku
+import Nimble
+import Quick
+import XCTest
+
+// swiftlint:disable line_length
+class DocumentConverterSpec: QuickSpec {
+    enum ParseError: LocalizedError {
+        case customError(message: String)
+        var localizedDescription: String {
+            switch self {
+            case .customError(let message):
+                return message
+            }
+        }
+    }
+
+    static func checkHeading(item: Block, identifier: String, expectedLevel: HeadingLevel, expectedText: String) throws {
+        guard let heading = item as? Heading else {
+            // It wasn't a heading. Report
+            throw ParseError.customError(message: "\(identifier): wasn't a heading, it was \(item)")
+        }
+        if heading.level != expectedLevel {
+            throw ParseError.customError(message: "\(identifier): expected heading level \(expectedLevel), but got \(heading.level)")
+        }
+        // We only expect 1 item for a heading
+        if heading.items.count != 1 {
+            throw ParseError.customError(message: "\(identifier): expected heading to only have 1 item, but it had \(heading.items)")
+        }
+        try DocumentConverterSpec.checkText(item: heading.items[0], identifier: identifier, expectedText: expectedText)
+    }
+
+    static func checkText(item: Inline, identifier: String, expectedText: String) throws {
+        guard let text = item as? Text else {
+            throw ParseError.customError(message: "\(identifier): expected Text, got \(item)")
+        }
+        if text.text != expectedText {
+            throw ParseError.customError(message: "\(identifier): expected \(expectedText), but got \(text.text)")
+        }
+    }
+
+    static func checkParagraph(item: Block, identifier: String, expectedText: [String?]) throws {
+        guard let paragraph = item as? Paragraph else {
+            throw ParseError.customError(message: "\(identifier): expected Paragraph, got \(item)")
+        }
+        if paragraph.items.count != expectedText.count {
+            throw ParseError.customError(message: "\(identifier): expected \(expectedText.count) items, but got \(paragraph.items.count)")
+        }
+        // swiftlint:disable identifier_name
+        for i in 0 ..< paragraph.items.count {
+            if let expectedString = expectedText[i] {
+                try DocumentConverterSpec.checkText(item: paragraph.items[i], identifier: "\(identifier) [item \(i)]", expectedText: expectedString)
+            } else {
+                // If the value in the expectedText array is nil, that means we expect a softbreak
+                if let item = paragraph.items[i] as? SoftBreak {
+                    // nothing to check.
+                } else {
+                    throw ParseError.customError(message: "\(identifier): expected item \(i) to be a soft break, but got \(paragraph.items[i])")
+                }
+            }
+        }
+    }
+
+    static func checkResults(items: [Block]) throws {
+        guard items.count == 4 else {
+            throw ParseError.customError(message: "Wrong number of elements")
+        }
+        // swiftlint:disable line_length
+        try DocumentConverterSpec.checkHeading(item: items[0], identifier: "first heading", expectedLevel: .h1, expectedText: "Heading 1")
+        try DocumentConverterSpec.checkHeading(item: items[1], identifier: "second heading", expectedLevel: .h2, expectedText: "Heading 2")
+        print("items[2] = \(items[2])")
+        try DocumentConverterSpec.checkParagraph(item: items[2], identifier: "first paragraph", expectedText: ["Simple paragraph", nil, "with two lines"])
+        try DocumentConverterSpec.checkParagraph(item: items[3], identifier: "second paragraph", expectedText: ["Another Paragraph"])
+        // swiftlint:enable line_length
+
+    }
+
+    // swiftlint:disable function_body_length
+    override func spec() {
+        // Be sure to change checkResults if you change this!
+        let markdown = """
+# Heading 1
+## Heading 2
+Simple paragraph
+with two lines
+
+Another Paragraph
+"""
+        describe("Parsing document") {
+            it("can work as normally expected to be called") {
+                do {
+                    let document = try Document(text: markdown)
+                    try DocumentConverterSpec.checkResults(items: document.items)
+                } catch ParseError.customError(let message) {
+                    fail(message)
+                } catch let error {
+                    fail("\(error.localizedDescription)")
+                }
+            }
+            it("works if a user calls convert on the document themselves to make a document") {
+                do {
+                    let cmDocument = try CMDocument(text: markdown)
+                    let converter = DocumentConverter()
+                    let convertedDoc = try converter.convert(document: cmDocument)
+                    try DocumentConverterSpec.checkResults(items: convertedDoc.items)
+                } catch ParseError.customError(let message) {
+                    fail(message)
+                } catch let error {
+                    fail("\(error.localizedDescription)")
+                }
+            }
+            it("works if a user converts the CMDocument node themselves, and never makes a Document") {
+                do {
+                    let cmDocument = try CMDocument(text: markdown)
+                    let converter = DocumentConverter()
+                    let items = try converter.convert(cmNode: cmDocument.node)
+                    try DocumentConverterSpec.checkResults(items: items)
+                } catch ParseError.customError(let message) {
+                    fail(message)
+                } catch let error {
+                    fail("\(error.localizedDescription)")
+                }
+            }
+            it("works if a user converts a subnode") {
+                do {
+                    let cmDocument = try CMDocument(text: markdown)
+                    let converter = DocumentConverter()
+                    let item1 = try converter.convert(cmNode: cmDocument.node.firstChild!)
+                    let item2 = try converter.convert(cmNode: cmDocument.node.firstChild!.next!)
+                    let item3 = try converter.convert(cmNode: cmDocument.node.firstChild!.next!.next!)
+                    let item4 = try converter.convert(cmNode: cmDocument.node.firstChild!.next!.next!.next!)
+                    try DocumentConverterSpec.checkResults(items: [item1[0], item2[0], item3[0], item4[0]])
+                } catch ParseError.customError(let message) {
+                    fail(message)
+                } catch let error {
+                    fail("\(error.localizedDescription)")
+                }
+            }
+        }
+    }
+}

--- a/Tests/MaakuTests/Core/DocumentConverterSpec.swift
+++ b/Tests/MaakuTests/Core/DocumentConverterSpec.swift
@@ -60,9 +60,8 @@ class DocumentConverterSpec: QuickSpec {
                 try DocumentConverterSpec.checkText(item: paragraph.items[i], identifier: "\(identifier) [item \(i)]", expectedText: expectedString)
             } else {
                 // If the value in the expectedText array is nil, that means we expect a softbreak
-                if let item = paragraph.items[i] as? SoftBreak {
-                    // nothing to check.
-                } else {
+                // If we didn't get one, that's a problem
+                if !(paragraph.items[i] is SoftBreak) {
                     throw ParseError.customError(message: "\(identifier): expected item \(i) to be a soft break, but got \(paragraph.items[i])")
                 }
             }


### PR DESCRIPTION
… document.

This addresses issue #40 

It allows individual nodes to be "parsed", providing more flexibility to the callers.