### PR TITLE
Change names to be more descriptive

### DIFF
--- a/Sources/Maaku/CMark/CMNode+ASTManipulation.swift
+++ b/Sources/Maaku/CMark/CMNode+ASTManipulation.swift
@@ -75,18 +75,18 @@ public extension CMNode {
         }
     }
 
-    func setDestination(_ newValue: String) throws {
+    func setLinkDestination(_ newValue: String) throws {
         // cmark_node_set_url copies the string
         if cmark_node_set_url(cmarkNode, newValue) != 1 {
             throw ASTError.canNotSetValue
         }
     }
 
-    func setURL(_ newValue: URL) throws {
-        try setDestination(newValue.absoluteString)
+    func setLinkURL(_ newValue: URL) throws {
+        try setLinkDestination(newValue.absoluteString)
     }
 
-    func setTitle(_ newValue: String) throws {
+    func setLinkTitle(_ newValue: String) throws {
         // cmark_node_set_title copies the string
         if cmark_node_set_title(cmarkNode, newValue) != 1 {
             throw ASTError.canNotSetValue

--- a/Sources/Maaku/CMark/CMNode.swift
+++ b/Sources/Maaku/CMark/CMNode.swift
@@ -188,8 +188,8 @@ public extension CMNode {
         return cmark_node_get_list_tight(cmarkNode) != 0
     }
 
-    /// The URL as a string.
-    var destination: String? {
+    /// The link URL as a string.
+    var linkDestination: String? {
         guard let buffer = cmark_node_get_url(cmarkNode) else {
             return nil
         }
@@ -197,17 +197,17 @@ public extension CMNode {
         return String(cString: buffer)
     }
 
-    /// The URL.
-    var url: URL? {
-        guard let destination = destination else {
+    /// The link URL.
+    var linkUrl: URL? {
+        guard let destination = linkDestination else {
             return nil
         }
 
         return URL(string: destination)
     }
 
-    /// The title.
-    var title: String? {
+    /// The link title.
+    var linkTitle: String? {
         guard let buffer = cmark_node_get_title(cmarkNode) else {
             return nil
         }

--- a/Sources/Maaku/CMark/CMParser.swift
+++ b/Sources/Maaku/CMark/CMParser.swift
@@ -507,15 +507,15 @@ public class CMParser {
             }
         case .link:
             if eventType == .enter {
-                try delegate?.parser(parser: self, didStartLinkWithDestination: node.destination, title: node.title)
+                try delegate?.parser(parser: self, didStartLinkWithDestination: node.linkDestination, title: node.linkTitle)
             } else {
-                try delegate?.parser(parser: self, didEndLinkWithDestination: node.destination, title: node.title)
+                try delegate?.parser(parser: self, didEndLinkWithDestination: node.linkDestination, title: node.linkTitle)
             }
         case .image:
             if eventType == .enter {
-                try delegate?.parser(parser: self, didStartImageWithDestination: node.destination, title: node.title)
+                try delegate?.parser(parser: self, didStartImageWithDestination: node.linkDestination, title: node.linkTitle)
             } else {
-                try delegate?.parser(parser: self, didEndImageWithDestination: node.destination, title: node.title)
+                try delegate?.parser(parser: self, didEndImageWithDestination: node.linkDestination, title: node.linkTitle)
             }
         case .htmlBlock:
             try delegate?.parser(parser: self, foundHtml: node.stringValue ?? "")

--- a/Tests/MaakuTests/CMark/CMNodeSpec.swift
+++ b/Tests/MaakuTests/CMark/CMNodeSpec.swift
@@ -164,9 +164,9 @@ class CMNodeSpec: QuickSpec {
                         expect(try doc.node.setListDelimiterType(.period)).to(throwError(CMNode.ASTError.canNotSetValue))
                         expect(try doc.node.setListStartingNumber(3)).to(throwError(CMNode.ASTError.canNotSetValue))
                         expect(try doc.node.setListTight(false)).to(throwError(CMNode.ASTError.canNotSetValue))
-                        expect(try doc.node.setDestination("dummy string")).to(throwError(CMNode.ASTError.canNotSetValue))
-                        expect(try doc.node.setURL(URL(string: "http://google.com")!)).to(throwError(CMNode.ASTError.canNotSetValue))
-                        expect(try doc.node.setTitle("dummy string")).to(throwError(CMNode.ASTError.canNotSetValue))
+                        expect(try doc.node.setLinkDestination("dummy string")).to(throwError(CMNode.ASTError.canNotSetValue))
+                        expect(try doc.node.setLinkURL(URL(string: "http://google.com")!)).to(throwError(CMNode.ASTError.canNotSetValue))
+                        expect(try doc.node.setLinkTitle("dummy string")).to(throwError(CMNode.ASTError.canNotSetValue))
                         expect(try doc.node.setLiteral("dummy string")).to(throwError(CMNode.ASTError.canNotSetValue))
                         // swiftlint:enable line_length
                     }
@@ -256,11 +256,11 @@ some text
                     do {
                         let doc = try CMDocument(text: "[my info](http://google.com)")
                         let linkNode = doc.node.firstChild!.firstChild!
-                        expect(linkNode.title).to(equal(""))
-                        try linkNode.setTitle("A new title")
-                        expect(linkNode.title).to(equal("A new title"))
-                        try linkNode.setURL(URL(string: "http://apple.com")!)
-                        expect(linkNode.destination).to(equal("http://apple.com"))
+                        expect(linkNode.linkTitle).to(equal(""))
+                        try linkNode.setLinkTitle("A new title")
+                        expect(linkNode.linkTitle).to(equal("A new title"))
+                        try linkNode.setLinkURL(URL(string: "http://apple.com")!)
+                        expect(linkNode.linkDestination).to(equal("http://apple.com"))
                         let result = try doc.renderCommonMark(width: 100)
                         expect(result).to(equal("[my info](http://apple.com \"A new title\")\n"))
                     }


### PR DESCRIPTION
Change from `title` to `linkTitle`, `destination` to `linkDestination`, and `url` to `linkURL` (both getter and setter) in `CMNode` to be more descriptive, since a `CMNode` might be of any type, and `title` especially can be very confusing.

Did not change `Image` or `Link` structures, as the structure itself qualifies the meaning of "destination" and "title".

Addresses #47 