### PR TITLE
Add ability to set task completed

### DIFF
--- a/Sources/Maaku/CMark/CMNode+ASTManipulation.swift
+++ b/Sources/Maaku/CMark/CMNode+ASTManipulation.swift
@@ -100,6 +100,12 @@ public extension CMNode {
         }
     }
 
+    func setTaskCompleted(_ newValue: Bool) throws {
+        if cmark_gfm_extensions_set_tasklist_item_checked(cmarkNode, newValue) != 1 {
+            throw ASTError.canNotSetValue
+        }
+    }
+
     /// Inserts this node into the AST before the given node
     ///
     /// - Parameters:

--- a/Sources/Maaku/CMark/CMNode+Task.swift
+++ b/Sources/Maaku/CMark/CMNode+Task.swift
@@ -16,6 +16,6 @@ public extension CMNode {
         guard humanReadableType == CMExtensionName.tasklist.rawValue else {
             return nil
         }
-        return cmark_gfm_extensions_tasklist_state_is_checked(cmarkNode)
+        return cmark_gfm_extensions_get_tasklist_item_checked(cmarkNode)
     }
 }

--- a/Tests/MaakuTests/CMark/CMExtensionTasklist.swift
+++ b/Tests/MaakuTests/CMark/CMExtensionTasklist.swift
@@ -124,6 +124,33 @@ class CMExtensionTasklistSpec: QuickSpec {
                         }
                     }
                 }
+                it("can modify the tasklist state") {
+                    do {
+                        let text =
+"""
+- [ ] task
+
+"""
+                        let doc = try CMDocument(text: text, options: .default, extensions: .tasklist)
+                        expect(try doc.renderCommonMark(width: 0)).to(equal(text))
+                        let listNode = doc.node.firstChild!
+                        // swiftlint:disable:next line_length
+                        expect(try listNode.setTaskCompleted(false)).to(throwError(CMNode.ASTError.canNotSetValue))
+                        let taskNode = listNode.firstChild!
+                        expect(taskNode.humanReadableType).to(equal("tasklist"))
+                        expect(taskNode.taskCompleted).to(equal(false))
+                        expect(try taskNode.setTaskCompleted(true)).toNot(throwError())
+                        expect(taskNode.taskCompleted).to(equal(true))
+                        expect(try doc.renderCommonMark(width: 0)).to(equal(text.replacingOccurrences(of: "[ ]", with: "[x]")))
+                        expect(try taskNode.setTaskCompleted(false)).toNot(throwError())
+                        expect(taskNode.taskCompleted).to(equal(false))
+                        expect(try doc.renderCommonMark(width: 0)).to(equal(text))
+                    } catch let error {
+                        it("fails to initialize the document") {
+                            fail("\(error.localizedDescription)")
+                        }
+                    }
+                }
             }
         }
         describe("render document") {


### PR DESCRIPTION
This adds the ability to set a tasklist item to completed. It depends on some changes to cmark-gfm (pull request [github/cmark-gfm/162](https://github.com/github/cmark-gfm/pull/162)). Once that is approved and integrated into cmark-gfm, then that stuff can be integrated into libcmark_gfm, and _then_ this can pull request can be processed.

This helps satisfy issue #45.