### PR TITLE
Add supported platforms to SwiftPM manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,12 @@ import PackageDescription
 
 let package = Package(
     name: "Maaku",
+    platforms: [
+      .macOS(.v10_11),
+      .iOS(.v9),
+      .tvOS(.v9),
+      .watchOS(.v2)
+    ],
     products: [
         .library(
             name: "Maaku",


### PR DESCRIPTION
This configures the SwiftPM manifest to match the minimum supported platforms from the pod spec. When I cloned Maaku I ran into a compilation issue on Xcode 12.2 beta 3 because the compilation target was set to macOS `10.10` by default, despite my project's deployment target being set to `11.0`, and this resolves the issue. 